### PR TITLE
Don't show TableOfContents section if empty

### DIFF
--- a/exampleSite/content/docs/user-guide/page1.md
+++ b/exampleSite/content/docs/user-guide/page1.md
@@ -1,6 +1,7 @@
 ---
 title: User Guide Page 1
 weight: 1
+notoc: true
 tags:
   - docs
   - howto

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -12,7 +12,7 @@ written permission of Adobe.
 */}}
 <div class="u-coral-margin">
 {{ partial "page-meta-links.html" . }}
-{{ if not .Params.notoc }}
+{{ if and (not .Params.notoc) (gt (len .TableOfContents) 32)  }}
   {{ with .TableOfContents }}
     {{ if ge (len .) 2 }}
       <h3 class="coral-Heading--3">Table of contents</h3>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't show ToC if emtpy.
This is mainly for section pages which are automatically generated and don't require a ToC
Couldn't find a better way to check if ToC is empty other than verify against default value which is 32 chars.
